### PR TITLE
feat: add a constraint to Device.name field.

### DIFF
--- a/openems/models/device.py
+++ b/openems/models/device.py
@@ -1,4 +1,4 @@
-from odoo import api, fields, models
+from odoo import api, fields, models, exceptions
 from datetime import datetime
 
 class Device(models.Model):
@@ -118,6 +118,15 @@ class Device(models.Model):
         elif string == "fault":
             state = 3
         return state
+
+    # Custom Constraints
+    def write(self, vals):
+        """Profibit to change name field after creation."""
+        if 'name' in vals:
+            for record in self:
+                if record.id and record.name != vals['name']:
+                    raise exceptions.UserError("The name of the device cannot be changed after creation.")
+        return super(Device, self).write(vals)
 
 
 class DeviceTag(models.Model):

--- a/openems/views/device.xml
+++ b/openems/views/device.xml
@@ -80,7 +80,7 @@
                         <h1>
                             <field name="comment" nolabel="True" />
                         </h1>
-                        <field name="name" readonly="1" />
+                        <field name="name" />
                         <field name="monitoring_url" widget="url" />
                     </group>
                     <notebook>


### PR DESCRIPTION
originally Device.name field is readonly in webui to avoid mis-operation when updating device information and force to use API.

this commit changes Device.name field can be edit when creating by using odoo custom constraints.

if you want to know detail of original code requirement and background, see also https://github.com/OpenEMS/odoo-openems/pull/4#pullrequestreview-1754089294
