### PR TITLE
fix: exception occurred when extracting the 'From' field

### DIFF
--- a/openems/mail/openems/alerting_offline.xml
+++ b/openems/mail/openems/alerting_offline.xml
@@ -4,7 +4,7 @@
         <record id="alerting_offline" model="mail.template">
             <field name="name">E-Mail Offline-Alerting</field>
             <field name="model_id" ref="model_openems_alerting" />
-            <field name="email_from"><![CDATA[OpenEMS Association e.V.<noreply@openems.io>]]></field>
+            <field name="email_from"><![CDATA[OpenEMS Association e.V. <noreply@openems.io>]]></field>
             <field name="partner_to">{{object.user_id.partner_id.id}}</field>
             <field name="subject">OpenEMS Alert - Edge is offline</field>
             <field name="body_html"><![CDATA[

--- a/openems/mail/openems/alerting_sum_state.xml
+++ b/openems/mail/openems/alerting_sum_state.xml
@@ -4,7 +4,7 @@
         <record id="alerting_sum_state" model="mail.template">
             <field name="name">E-Mail SumState Alerting</field>
             <field name="model_id" ref="model_openems_alerting" />
-            <field name="email_from"><![CDATA[OpenEMS Association e.V.<noreply@openems.io>]]></field>
+            <field name="email_from"><![CDATA[OpenEMS Association e.V. <noreply@openems.io>]]></field>
             <field name="partner_to">{{object.user_id.partner_id.id}}</field>
             <field name="subject">OpenEMS Alert - Edge is in {{object.device_id.openems_sum_state_level}} State</field>
             <field name="body_html"><![CDATA[

--- a/openems/mail/openems/setup_protocol_customer.xml
+++ b/openems/mail/openems/setup_protocol_customer.xml
@@ -4,7 +4,7 @@
         <record id="setup_protocol_email_customer" model="mail.template">
             <field name="name">E-Mail setup protocol for customer</field>
             <field name="model_id" ref="model_openems_setup_protocol" />
-            <field name="email_from"><![CDATA[OpenEMS Association e.V.<noreply@openems.io>]]></field>
+            <field name="email_from"><![CDATA[OpenEMS Association e.V. <noreply@openems.io>]]></field>
             <field name="partner_to">{{object.customer_id.id}}</field>
             <field name="subject"
             >Your OpenEMS setup protocol for {{object.openems_device_id.name}}</field>

--- a/openems/mail/openems/setup_protocol_installer.xml
+++ b/openems/mail/openems/setup_protocol_installer.xml
@@ -4,7 +4,7 @@
         <record id="setup_protocol_email_installer" model="mail.template">
             <field name="name">E-Mail setup protocol for installer</field>
             <field name="model_id" ref="model_openems_setup_protocol" />
-            <field name="email_from"><![CDATA[OpenEMS Association e.V.<noreply@openems.io>]]></field>
+            <field name="email_from"><![CDATA[OpenEMS Association e.V. <noreply@openems.io>]]></field>
             <field name="partner_to">{{object.installer_id.id}}</field>
             <field name="subject"
             >Your OpenEMS setup protocol for {{object.openems_device_id.name}}</field>

--- a/openems/mail/openems/user_registration.xml
+++ b/openems/mail/openems/user_registration.xml
@@ -4,7 +4,7 @@
         <record id="registration_email" model="mail.template">
             <field name="name">E-Mail Kunden Registrierung</field>
             <field name="model_id" ref="base.model_res_partner" />
-            <field name="email_from"><![CDATA[OpenEMS Association e.V.<noreply@openems.io>]]></field>
+            <field name="email_from"><![CDATA[OpenEMS Association e.V. <noreply@openems.io>]]></field>
             <field name="partner_to">{{object.id}}</field>
             <field name="subject">Registrierung erfolgreich</field>
             <field name="auto_delete">false</field>


### PR DESCRIPTION
Alerting function is not working as expected. when an edge is set offline, alerting email will not be sent and the following odoo error will show:

```
2024-04-16 05:29:14,092 2797060 DEBUG odoo odoo.tools.translate: no translation language detected, skipping translation for "'Error without exception. Probably due to sending an email without computed recipients.'"                        
2024-04-16 05:29:14,096 2797060 ERROR odoo odoo.addons.mail.models.mail_mail: failed sending mail (id: 161) due to 'str' object has no attribute 'token_type'                                                                                 
Traceback (most recent call last):                                                                                                                                                                                                            
  File "/usr/lib/python3/dist-packages/odoo/addons/mail/models/mail_mail.py", line 550, in _send                                                                                                                                              
    res = IrMailServer.send_email(                                                                                                                                                                                                            
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_mail_server.py", line 673, in send_email                                                                                                                                    
    smtp_from, smtp_to_list, message = self._prepare_email_message(message, smtp)                                                                                                                                                             
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_mail_server.py", line 613, in _prepare_email_message                                                                                                                        
    message['From'] = smtp_from                                                                                                                                                                                                               
  File "/usr/lib/python3.10/email/message.py", line 409, in __setitem__                                                                                                                                                                       
    self._headers.append(self.policy.header_store_parse(name, val))                                                                                                                                                                           
  File "/usr/lib/python3.10/email/policy.py", line 148, in header_store_parse                                                                                                                                                                 
    return (name, self.header_factory(name, value))                                                                                                                                                                                           
  File "/usr/lib/python3.10/email/headerregistry.py", line 604, in __call__                                                                                                                                                                   
    return self[name](name, value)                                                                                                                                                                                                            
  File "/usr/lib/python3.10/email/headerregistry.py", line 192, in __new__
    cls.parse(value, kwds)
  File "/usr/lib/python3.10/email/headerregistry.py", line 346, in parse
    [Address(mb.display_name or '',
  File "/usr/lib/python3.10/email/headerregistry.py", line 346, in <listcomp>
    [Address(mb.display_name or '',
  File "/usr/lib/python3.10/email/_header_value_parser.py", line 462, in display_name
    return self[0].display_name
  File "/usr/lib/python3.10/email/_header_value_parser.py", line 393, in display_name
    return self[0].display_name
  File "/usr/lib/python3.10/email/_header_value_parser.py", line 574, in display_name
    if res[-1][-1].token_type == 'cfws':
AttributeError: 'str' object has no attribute 'token_type'
```

The issue was that an exception occurred when extracting the 'From' field of the created mail object (https://github.com/odoo/odoo/blob/b278241a7192640fcb33fab2dd2bdfd27a93af7d/odoo/addons/base/models/ir_mail_server.py#L609), which is related to a longstanding problem in Python (https://bugs.python.org/issue30988) where headers are not nicely normalized and instead throw an error if not compliant with RFC.

```
>>> import email
>>> from email.policy import SMTP
>>> email.message_from_bytes(b'From: OpenEMS Association e.V.<noreply@openems.io>')['From']
'OpenEMS Association e.V.<noreply@openems.io>'
>>> email.message_from_bytes(b'From: OpenEMS Association e.V.<noreply@openems.io>', policy=SMTP)['From']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/message.py", line 391, in __getitem__
    return self.get(name)
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/message.py", line 471, in get
    return self.policy.header_fetch_parse(k, v)
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/policy.py", line 163, in header_fetch_parse
    return self.header_factory(name, value)
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/headerregistry.py", line 604, in __call__
    return self[name](name, value)
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/headerregistry.py", line 192, in __new__
    cls.parse(value, kwds)
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/headerregistry.py", line 346, in parse
    [Address(mb.display_name or '',
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/headerregistry.py", line 346, in <listcomp>
    [Address(mb.display_name or '',
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/_header_value_parser.py", line 462, in display_name
    return self[0].display_name
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/_header_value_parser.py", line 393, in display_name
    return self[0].display_name
  File "/Users/katsuya/.rye/py/cpython@3.10.13/install/lib/python3.10/email/_header_value_parser.py", line 574, in display_name
    if res[-1][-1].token_type == 'cfws':
AttributeError: 'str' object has no attribute 'token_type'
>>> email.message_from_bytes(b'From: OpenEMS Association e.V. <noreply@openems.io>', policy=SMTP)['From']
'"OpenEMS Association e.V." <noreply@openems.io>'
```