### PR TITLE
fix: domain_force for device ignored and bypassed

### DIFF
--- a/openems/security/openems.xml
+++ b/openems/security/openems.xml
@@ -29,8 +29,7 @@
             name="name"
         >Website: Show only approved devices to Portal and User</field>
         <field name="model_id" ref="model_openems_device" />
-        <field name="domain_force">[('user_role_ids.user_id','in',[user.id])]</field>
-        <field name="domain_force">[('alerting_settings.user_id','in',[user.id])]</field>
+        <field name="domain_force">['|', ('user_role_ids.user_id','in',[user.id]), ('alerting_settings.user_id','in',[user.id])]</field>
         <field
             name="groups"
             eval="[(4, ref('base.group_portal')), (4, ref('base.group_user'))]"


### PR DESCRIPTION
When not using alerting, devices that should normally be retrieved are not being obtained.

In version 16.0, the following rule specifies two domain_force entries for the device. However, specifying two domain_force entries is not allowed, and the first entry is not effective. As a result, when not using alerting, devices that should normally be retrieved are not being obtained.

https://github.com/OpenEMS/odoo-openems/blob/76dca062f3bbf66436fa813e8570557da0953f89/openems/security/openems.xml#L27-L42

The following is the SQL issued for the device in version 16.0
```sql
SELECT
    "openems_device".id
FROM
    "openems_device"
WHERE ("openems_device"."active" = TRUE)
    AND ("openems_device"."id" IN (
            SELECT
                "openems_device_user_role"."device_id"
            FROM
                "openems_device_user_role"
            WHERE ("openems_device_user_role"."user_id" IN (8))
            AND "openems_device_user_role"."device_id" IS NOT NULL))
ORDER BY
    "openems_device"."name_number" ASC
LIMIT 20
```

The following is the SQL issued for the device in version 15.0
```sql
SELECT
    "openems_device".id
FROM
    "openems_device"
WHERE ("openems_device"."active" = TRUE)
    AND ("openems_device"."id" IN (
            SELECT
                "openems_device_user_role"."device_id"
            FROM
                "openems_device_user_role"
            WHERE ("openems_device_user_role"."user_id" IN (8))
            AND "openems_device_user_role"."device_id" IS NOT NULL))
ORDER BY
    "openems_device"."name_number" ASC
LIMIT 20
```